### PR TITLE
Override requiredSystemFeatures from linuxkit kernel

### DIFF
--- a/linuxkit-builder/default.nix
+++ b/linuxkit-builder/default.nix
@@ -32,7 +32,7 @@
 , gnugrep
 , ed
 , substituteAll
-, linuxkitKernel ? (forceSystem "x86_64-linux" "x86_64").callPackage ./kernel.nix { }
+, linuxkitKernel ? ((forceSystem "x86_64-linux" "x86_64").callPackage ./kernel.nix { }).overrideAttrs (oldAttrs: { requiredSystemFeatures = [ ];  })
 , storeDir ? builtins.storeDir
 
 , hostPort ? "24083"


### PR DESCRIPTION
This allows to build the linuxkit kernel with [docker remote builder](https://github.com/LnL7/nix-docker#running-as-a-remote-builder), which does not have the [feature `big-parallel`](https://github.com/NixOS/nixpkgs/issues/16263
), otherwise fails with the message:
```
error: a 'x86_64-linux' is required to build '/nix/store/dgp6lijq18a0jvvni12nv3hqqkvf0rpp-linux-4.9.107-linuxkit.drv', but I am a 'x86_64-darwin'
```