### PR TITLE
Verify contents on startup

### DIFF
--- a/linuxkit-builder/stage-2.sh
+++ b/linuxkit-builder/stage-2.sh
@@ -49,6 +49,7 @@ ls -la /nix/var/nix/db || true
 
 if [ -f /nix-path-registration ]; then
   nix-store --load-db < /nix-path-registration
+  nix-store --verify --check-contents
   rm /nix-path-registration
 fi
 


### PR DESCRIPTION
Without this when building VMs inside of it, you might get:

```hash mismatch importing path '/nix/store/2kcrj1ksd2a14bm5sky182fv2xwfhfap-glibc-2.26-131'; expected hash 'sha256:0000000000000000000000000000000000000000000000000000', got 'sha256:1advm2fxdviczlnmfyskk1gvipws9kwv4pg1mvinlf6xqd0xl45n'```

or similar.