### PR TITLE
Remove unnecessary step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 Fetch it from the NixOS binary cache:
 
-    nix-store -r /nix/store/1f5zgx8qykz2fxzhqphmsfp6cvpnfc94-linuxkit-builder
     nix-env -i /nix/store/1f5zgx8qykz2fxzhqphmsfp6cvpnfc94-linuxkit-builder
     nix-linuxkit-configure
     


### PR DESCRIPTION
`nix-env` will realize store paths. I love it!